### PR TITLE
Add login screen with navigation to registration

### DIFF
--- a/login.html
+++ b/login.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>ログイン画面</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 40px;
+            background-color: #f8f8f8;
+        }
+        .container {
+            background: #fff;
+            padding: 24px 32px;
+            border-radius: 8px;
+            max-width: 400px;
+            margin: auto;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        }
+        h2 {
+            text-align: center;
+            margin-bottom: 24px;
+        }
+        label {
+            display: block;
+            margin-top: 16px;
+            margin-bottom: 4px;
+            font-weight: bold;
+        }
+        input[type="email"],
+        input[type="password"] {
+            width: 100%;
+            padding: 8px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            box-sizing: border-box;
+        }
+        button {
+            margin-top: 24px;
+            width: 100%;
+            padding: 10px;
+            background-color: #0078d4;
+            color: #fff;
+            border: none;
+            border-radius: 4px;
+            font-size: 16px;
+            cursor: pointer;
+        }
+        button:hover {
+            background-color: #005fa3;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h2>ログイン</h2>
+        <form>
+            <label for="email">メールアドレス</label>
+            <input type="email" id="email" name="email" required>
+
+            <label for="password">パスワード</label>
+            <input type="password" id="password" name="password" required>
+
+            <button type="submit">ログイン</button>
+        </form>
+        <button type="button" id="register-btn">新規登録</button>
+    </div>
+    <script>
+        document.getElementById('register-btn').addEventListener('click', function() {
+            window.location.href = 'UserEntry.html';
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple `login.html` with email and password fields
- include login and registration buttons
- registration button links to the existing member registration screen

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68580b4ac4008324afe7607431f48ea8